### PR TITLE
Add `has no effect` pattern

### DIFF
--- a/patterns.js
+++ b/patterns.js
@@ -304,7 +304,7 @@ export const patterns = {
     replace: ['cheap']
   },
   effect: {
-    replace: ['choose', 'pick']
+    replace: ['choose', 'pick', 'result']
   },
   'effect modifications': {
     replace: ['make changes']
@@ -425,6 +425,9 @@ export const patterns = {
   },
   'has a requirement for': {
     replace: ['needs']
+  },
+  'has no effect': {
+    replace: ['does nothing', 'does not apply']
   },
   herein: {
     replace: ['here']

--- a/test.js
+++ b/test.js
@@ -3,7 +3,7 @@ import {retext} from 'retext'
 import retextSimplify from './index.js'
 
 test('retext-simplify', (t) => {
-  t.plan(4)
+  t.plan(5)
 
   retext()
     .use(retextSimplify)
@@ -69,6 +69,20 @@ test('retext-simplify', (t) => {
         file.messages.map((d) => String(d)),
         [],
         'should not warn for ignored phrases'
+      )
+    }, t.ifErr)
+
+  retext()
+    .use(retextSimplify)
+    .process('This method has no effect')
+    .then((file) => {
+      t.deepEqual(
+        file.messages.map((d) => String(d)),
+        [
+          '1:13-1:26: Replace `has no effect` with `does nothing`, `does not apply`',
+          '1:20-1:26: Replace `effect` with `choose`, `pick`, `result`'
+        ],
+        'should warn about simpler synonyms'
       )
     }, t.ifErr)
 })


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/retextjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/retextjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/retextjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aretextjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Fixes: https://github.com/retextjs/retext-simplify/issues/13

<!--do not edit: pr-->
